### PR TITLE
Updated src directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ From the project root where this `README.md` is located, build using the
 standard `go` tool:
 
 ```
-cd $GOPATH/github.com/feedhenry/openshift-template-tool
+cd $GOPATH/src/github.com/feedhenry/openshift-template-tool
 go install
 ```
 


### PR DESCRIPTION
Small update in README.md that would point to src directory. This is default directory that would be used when using go get.
